### PR TITLE
Tags the bundle with the repository owner before pushing 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.GHCR_PASSWORD }}
       - name: Retag bundle for ghcr.io
         run: |
-          sed -i.bu 's/squillace\//\//g' ./porter.yaml
+          sed -i.bu 's/squillace\//squillace\//g' ./porter.yaml
           grep "tag:" ./porter.yaml
           grep "version" ./porter.yaml
       - name: Porter publish to ghcr.io

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.
+      - name: Setup Porter
+        # You may pin to the exact commit or the version.
+        # uses: getporter/gh-action@d8539f57d75587d98651fc94de9e7e63abfaf75e
+        uses: getporter/gh-action@v0.1.1
+      - name: Pull in helm3 mixin
+        run: porter mixins install helm3 --url https://github.com/MChorfa/porter-helm3/releases/download --version v0.1.7
+      - name: Login to GitHub Packages OCI Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PASSWORD }}
+      - name: Retag bundle for ghcr.io
+        run: |
+          sed -i.bu 's/squillace\//\//g' ./porter.yaml
+          grep "tag:" ./porter.yaml
+          grep "version" ./porter.yaml
+      - name: Porter publish to ghcr.io
+        run: porter publish
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 Have you ever wondered what an application architecture would look like if you committed to using mostly all graduated or incubating projects from the [Cloud Native Computing Foundation](https://www.cncf.io/projects/)? This repo, the **[CNCF](https://www.cncf.io/) Projects App**, attempts to answer that question with an example expense application that is made up almost exclusively of CNCF projects. 
 
 ## Table of Contents
--[Overview](#overview)
+- [Overview](#overview)
+- [CNCF Projects App Overview](#cncf-projects-app-overview)
+- [CNCF Projects App Architecture](#cncf-projects-app-architecture)
+- [Install](#install)
+- [Contributing](#contributing)
+
 
 ## Overview
 The CNCF Projects App project and application is not to be considered a reference architecture for any of the CNCF projects in use, but to serve as an "art of the possible" with the goal of using as many CNCF projects as possible to create a functional real world application. The project goal to encourage new people venturing into the world of open source, and specifically the CNCF community, to participate and provide high-level guidance on what each CNCF project capablities are and how the project can function for a true business application. We hope this sample application becomes a reference starting point for those getting started in the open source community, as well as seasoned maintainers and contributors to work along on this project to extend it in various scenarios.


### PR DESCRIPTION
Soon porter will be able to be tagged directly, but for now I want to whack the tag with the repository owner so that the pushed bundle is owned properly no matter who clones/forks the repo.