### PR TITLE
Installing up to DNS; uninstalling as well

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y ca-certificates
 # PORTER_MIXINS
 
 # Use the BUNDLE_DIR build argument to copy files into the bundle
+RUN helm3 repo update
 COPY . $BUNDLE_DIR

--- a/cert-manager.sh
+++ b/cert-manager.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+export ns=$1
+  
+helm3 upgrade --install cert-manager --namespace $1 --version v0.16.1 --set installCRDs=true --set nodeSelector."beta\.kubernetes\.io/os"=linux jetstack/cert-manager --wait 

--- a/cluster-issuer.sh
+++ b/cluster-issuer.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+email=$1
+
+sleep 30
+
+cat <<EOF | kubectl create -f -
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+  namespace: ingress-basic
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: $email
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - http01:
+        ingress:
+          class: harbor-nginx
+          podTemplate:
+            spec:
+              nodeSelector:
+                "kubernetes.io/os": linux      
+EOF

--- a/delete-cluster-issuer.sh
+++ b/delete-cluster-issuer.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+email=$1
+
+#sleep 10
+
+cat <<EOF | kubectl delete -f -
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+  namespace: ingress-basic
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: $email
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - http01:
+        ingress:
+          class: harbor-nginx
+          podTemplate:
+            spec:
+              nodeSelector:
+                "kubernetes.io/os": linux      
+EOF

--- a/harbor-system-ingress.sh
+++ b/harbor-system-ingress.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export ns=$1
-helm3 install harbor-nginx-ingress stable/nginx-ingress \
+helm3 upgrade --install harbor-nginx-ingress ingress-nginx/ingress-nginx \
     --namespace "$1" \
     --set controller.ingressClass=harbor-nginx \
     --set controller.replicaCount=2 \

--- a/nginx-ingress.sh
+++ b/nginx-ingress.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export ns=$1
-helm3 install nginx-ingress stable/nginx-ingress --namespace "$1" --replace --wait --set controller.nodeSelector."beta\.kubernetes\.io/os"=linux --set controller.replicaCount=2 --set defaultBackend.nodeSelector."beta\.kubernetes\.io/os"=linux
+helm3 upgrade --install nginx-ingress stable/nginx-ingress --namespace "$1" --wait --set controller.nodeSelector."beta\.kubernetes\.io/os"=linux --set controller.replicaCount=2 --set defaultBackend.nodeSelector."beta\.kubernetes\.io/os"=linux

--- a/porter.yaml
+++ b/porter.yaml
@@ -4,7 +4,7 @@
 # Uncomment out the sections below to take full advantage of what Porter can do!
 
 name: cncf-projects-app
-version: 0.1.4
+version: 0.1.5
 description: "A bundle that installs and removes the CNCF demo project. Use \'porter explain --tag <registry>/<organization>/<repository>/<image name>:version\' to display required and optional parameters, credentials, and outputs."
 tag: ghcr.io/squillace/cncf-projects-app/cncf
 
@@ -77,16 +77,59 @@ install:
         wait: true
   - exec:
       command: bash
-      description: "Creating the ingress namespace."
+      description: "Creating the harbor system ingress namespace."
       flags:
-          c: '"kubectl create namespace {{bundle.parameters.harbor-ingress-namespace}}"' 
+        c: '"kubectl create namespace {{bundle.parameters.harbor-ingress-namespace}}"' 
 
   - exec:
-        command: bash
-        description: "Installing the nginx ingress...."
+      command: bash
+      description: "Installing the harbor system ingress...."
+      arguments:
+          - "harbor-system-ingress.sh"
+          - "{{bundle.parameters.harbor-ingress-namespace}}"
+
+  - exec:
+      command: bash
+      description: "Label harbor ingress namespace for cert-manager...."
+      flags:
+        c: '"kubectl label namespace {{bundle.parameters.harbor-ingress-namespace}} cert-manager.io/disable-validation=true"'  
+          # kubectl label namespace harbor-ingress-system cert-manager.io/disable-validation=true
+
+  - exec:
+      command: bash
+      description: "Label ingress namespace for cert-manager...."
+      flags:
+        c: '"kubectl label namespace {{bundle.parameters.ingress-namespace}} cert-manager.io/disable-validation=true"'  
+          # kubectl label namespace ingress-basic cert-manager.io/disable-validation=true     
+  
+  - exec:
+      command: bash
+      description: "Installing cert manager for the basic ingress...."
+      arguments:
+          - "cert-manager.sh"
+          - "{{bundle.parameters.ingress-namespace}}"
+
+  - exec:
+      command: bash
+      description: "Installing the cluster issuer to work with cert manager...."
+      arguments:
+          - "cluster-issuer.sh"
+          - "{{bundle.parameters.cert-email-address}}"
+
+  - exec:
+        description: "Get harbor system ingress IP address...."
+        command: "kubectl"
         arguments:
-            - "harbor-system-ingress.sh"
-            - "{{bundle.parameters.harbor-ingress-namespace}}"
+          - "get"
+          - "service"
+          - "harbor-nginx-ingress-ingress-nginx-controller"
+        flags:
+          o: "json"
+          namespace: "{{bundle.parameters.harbor-ingress-namespace}}"
+        outputs:
+          - name: "harbor-lb-ip"
+            jsonPath: "$.status.loadBalancer.ingress[0].ip"
+
 upgrade:
   - exec:
       description: "TODO: understand what upgrade of this might mean."
@@ -95,15 +138,28 @@ upgrade:
         - upgrade
 
 uninstall:
+  - exec:
+      command: bash
+      description: "Deleting the cluster issuer to work with cert manager...."
+      arguments:
+        - "delete-cluster-issuer.sh"
+        - "{{bundle.parameters.cert-email-address}}"
 
   - helm3:
-      description: "Deleting the basic ingress Helm chart resources."
+      description: "Deleting the cert manager chart resources."
+      namespace: "{{bundle.parameters.ingress-namespace}}"
+      releases:
+        - "cert-manager" # parameterize?
+
+
+  - helm3:
+      description: "Deleting the harbor ingress Helm chart resources."
       namespace: "{{bundle.parameters.harbor-ingress-namespace}}"
       releases:
         - "harbor-nginx-ingress" # parameterize?
 
   - exec:
-      description: "delete "
+      description: "Deleting the harbor ingress namespace... "
       command: kubectl
       arguments:
         - delete
@@ -117,11 +173,7 @@ uninstall:
             - "yml/rook-cluster.yaml"
             - "yml/rook-operator.yaml"
 #            - "yml/rook-common.yaml"
-
         wait: true
-
-
-
 
   - helm3:
       description: "Deleting the basic ingress Helm chart resources."
@@ -130,12 +182,22 @@ uninstall:
         - "nginx-ingress" # parameterize?
 
   - exec:
-      description: "delete "
+      description: "Deleting the basic ingress namespace... "
       command: kubectl
       arguments:
         - delete
         - namespace
         - "{{bundle.parameters.ingress-namespace}}"
+
+
+ # until we figure out the race condition here, this will be the last task to purge your cluster       
+  - exec:
+      command: bash
+      description: '"Now run \"cat yml/rook-common.yaml | kubectl delete -f -\" to delete the remaining detritus."'
+      suppress-output: true
+      flags:
+          c: '"cat yml/rook-common.yaml | kubectl delete -f -"'
+
 
 # Below is an example of how to define credentials
 # See https://porter.sh/author-bundles/#credentials
@@ -150,9 +212,21 @@ credentials:
 # See https://porter.sh/author-bundles/#parameters
 parameters:
   - name: ingress-namespace
+    description: "The namespace given to the basic ingress."
     type: string
     default: ingress-basic
   - name: harbor-ingress-namespace
+    description: "The harbor system namespace."
     type: string
     default: harbor-ingress-system
+  - name: cert-email-address
+    description: "The email address passed to letsencrypt for the cluster issuer."
+    type: string
+    default: example@contoso.com
 
+outputs:
+    - name: harbor-lb-ip
+      description: "The IP address assigned to the harbor ingress load balancer."
+      type: string
+      appliesTo:
+        - install

--- a/porter.yaml
+++ b/porter.yaml
@@ -5,7 +5,7 @@
 
 name: cncf-projects-app
 version: 0.1.5
-description: "A bundle that installs and removes the CNCF demo project. Use \'porter explain --tag <registry>/<organization>/<repository>/<image name>:version\' to display required and optional parameters, credentials, and outputs."
+description: "A bundle that installs and removes the CNCF demo project. This application installs ngnix ingresses, Harbor, cert-manager & letsencrypt, rook/ceph, openfaas, and jaeger and prometheus, mysql|vitess, Linkerd, and Tekton."
 tag: ghcr.io/squillace/cncf-projects-app/cncf
 
 # Moves mixins up to the top for faster bundle dev iteration

--- a/porter.yaml
+++ b/porter.yaml
@@ -4,7 +4,7 @@
 # Uncomment out the sections below to take full advantage of what Porter can do!
 
 name: cncf-projects-app
-version: 0.1.3
+version: 0.1.4
 description: "A bundle that installs and removes the CNCF demo project. Use \'porter explain --tag <registry>/<organization>/<repository>/<image name>:version\' to display required and optional parameters, credentials, and outputs."
 tag: ghcr.io/squillace/cncf-projects-app/cncf
 
@@ -17,7 +17,7 @@ mixins:
   - helm3:
       #NOTE: the recently secured version of Helm 3 detects and fails the jetstack 
       # helm chart out due to an invalid yaml key "serverInfo"
-      clientVersion: v3.3.3
+      clientVersion: v3.3.4
       repositories:
         # Add the official stable repository
         stable:


### PR DESCRIPTION
Installing now up all the way to `Assign a DNS label to the Ingress Public IP and update it for the registryHost variable` in the readme. It also Uninstalls all the way with one clean up line left behind. I'll diagnose that issue with @fmustaf later. 



Try it! 

![image](https://user-images.githubusercontent.com/1422718/95541087-72d71080-09c0-11eb-82a3-582fbf6052f9.png)

Outputs the IP address of the harbor ingress loadbalancer. To see that, type `porter show cncf-projects-app`. 
![image](https://user-images.githubusercontent.com/1422718/95541189-bd588d00-09c0-11eb-94a1-34855656431d.png)
